### PR TITLE
#30 ansible shell module - args: warn is no longer supported

### DIFF
--- a/roles/ilmt_scanner/tasks/install_scanner_ibmi.yml
+++ b/roles/ilmt_scanner/tasks/install_scanner_ibmi.yml
@@ -115,7 +115,6 @@
       shell: "jar -xvf '{{ lmt_scanner_path_ibmi }}/{{ scanner_package_file }}'"
       args:
         chdir: "{{ lmt_scanner_path_ibmi }}/"
-        warn: false
 
     - name: "Remove scanner installer package from IBM i endpoints"
       file:

--- a/roles/ilmt_scanner/tasks/install_scanner_unix.yml
+++ b/roles/ilmt_scanner/tasks/install_scanner_unix.yml
@@ -131,7 +131,6 @@
       shell: "gzip -dc '{{ lmt_scanner_path_unix }}/{{ scanner_package_file }}' | tar -xf -"
       args:
         chdir: "{{ lmt_scanner_path_unix }}/"
-        warn: false
 
     - name: "Remove scanner installer package from UNIX/Linux endpoints"
       file:

--- a/roles/ilmt_scanner/tasks/uninstall_scanner_ibmi.yml
+++ b/roles/ilmt_scanner/tasks/uninstall_scanner_ibmi.yml
@@ -34,6 +34,4 @@
 
     - name: "Delete ILMT folder from IBM i endpoints"
       shell: "rm -rf \"{{ lmt_scanner_path_ibmi }}\""
-      args:
-        warn: false
   when: not (leave_config_backup | default(false))

--- a/roles/ilmt_scanner/tasks/uninstall_scanner_unix.yml
+++ b/roles/ilmt_scanner/tasks/uninstall_scanner_unix.yml
@@ -91,8 +91,6 @@
 
     - name: "Delete all data from ILMT scanner folder except config backup from UNIX/Linux endpoints"
       shell: "rm -rf \"{{ item.path }}\""
-      args:
-        warn: false
       with_items: "{{ found_files['files'] }}"
       loop_control:
         label: "{{ item.path | basename }}"
@@ -110,6 +108,4 @@
 
     - name: "Delete ILMT folder from UNIX/Linux endpoints"
       shell: "rm -rf \"{{ lmt_scanner_path_unix }}\""
-      args:
-        warn: false
   when: not (leave_config_backup | default(false))


### PR DESCRIPTION
shell module args:warn is deprecated from ansible version 2.14 onwards. 