### PR TITLE
Ilmt scanner windows

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,0 +1,7 @@
+---
+collections:
+  - chocolatey.chocolatey
+  - ansible.windows
+  - community.windows
+  - community.general
+  - microsoft.ad

--- a/lmt_install_or_upgrade_scanner.yml
+++ b/lmt_install_or_upgrade_scanner.yml
@@ -32,8 +32,8 @@
   tasks:
     - name: "Install or upgrade ILMT scanners on WINDOWS endpoints"
       become: true
-      become_user: system
-      become_method: runas
+      become_user: "{{ become_user }}"
+      become_method: "{{ become_method }}"
       block:
         - include_role:
             name: ilmt_scanner

--- a/roles/ilmt_scanner/tasks/get_scanner_facts_windows.yml
+++ b/roles/ilmt_scanner/tasks/get_scanner_facts_windows.yml
@@ -9,12 +9,12 @@
   register: windows_endpoint_id
   when: ilmt_scanner_installed_win.stat.exists
 
-- name: "Find isotag file on Windows endpoints"
-  win_find:
-    paths: "{{ lmt_scanner_path_windows }}\\iso-swid\\"
-    use_regex: true
-    patterns: ['^ibm.com_IBM_License_Metric_Tool-.+\.swidtag$']
-  register: scanner_swidtag_names
+#- name: "Find isotag file on Windows endpoints"
+#  win_find:
+#    paths: "{{ lmt_scanner_path_windows }}\\iso-swid\\"
+#    use_regex: true
+#    patterns: ['^ibm.com_IBM_License_Metric_Tool-.+\.swidtag$']
+#  register: scanner_swidtag_names
 
 - name: "Set scanner version variable on Windows endpoints"
   set_fact:

--- a/roles/ilmt_scanner/tasks/install_scanner_windows.yml
+++ b/roles/ilmt_scanner/tasks/install_scanner_windows.yml
@@ -72,7 +72,7 @@
         source_file: "{{ scanner_package_file }}"
       win_copy:
         src: "{{ lmt_local_file_storage_path + '/' + lmt_scanner_installers_folder + '/' + scanner_package_file }}"
-        dest: "{{ lmt_scanner_path_windows }}"
+        dest: "{{ lmt_scanner_path_windows }}\\"
         force: true
 
     - name: "Unpack Scanner package on WINDOWS endpoints"


### PR DESCRIPTION
- added requirements.yml

- Commented task "name: "Find isotag file on Windows endpoints", as it fails when path doesn't exists.

- add "\" otherwise getting error "cannot copy file to dest+ object at path is already a directory"

- removed hardcoded values for windows, put as vars which we are passing from the inventory.